### PR TITLE
Improve Warmup Results Screen + Sharing

### DIFF
--- a/QuizPlease/Modules/WarmUp/View/WarmupVC.swift
+++ b/QuizPlease/Modules/WarmUp/View/WarmupVC.swift
@@ -21,7 +21,7 @@ protocol WarmupViewProtocol: UIViewController, LoadingIndicator {
     func showNextQuestion()
     func highlightCurrentAnswer(isCorrect: Bool)
     func setQuestions()
-    func showResults(with totalTimePassed: Double)
+    func showResults(with totalTimePassed: Double, resultText: String)
     func updatePassedTime(withMinutes minutes: Int, seconds: Int)
 
     func makeResultsSnapshot() -> UIImage?
@@ -44,7 +44,11 @@ final class WarmupVC: UIViewController {
     @IBOutlet private var progressRing: UICircularProgressRing!
     @IBOutlet private weak var minutesPassedItem: UIBarButtonItem!
 
-    @IBOutlet private weak var completionView: UIView!
+    @IBOutlet private weak var completionView: UIView! {
+        didSet {
+            completionView.isHidden = true
+        }
+    }
     @IBOutlet private weak var resultsView: UIView!
     @IBOutlet private weak var resultTextLabel: UILabel!
     @IBOutlet private weak var minutesLabel: UILabel!
@@ -138,12 +142,8 @@ final class WarmupVC: UIViewController {
 
     // MARK: - Set Results
 
-    private func setResults(with totalTimePassed: Double) {
-        let count = presenter.questions.count
-        let correct = presenter.correctAnswersCount
-        let correctQuestionsPrompt = correct.string(withAssociatedMaleWord: "вопрос")
-        resultTextLabel.text = "Я прошел разминку Квиз,\(String.nonBreakingSpace)плиз! "
-        + "и ответил правильно на \(correctQuestionsPrompt) из \(count)"
+    private func setResults(with totalTimePassed: Double, resultText: String) {
+        resultTextLabel.text = resultText
 
         let passedTime = totalTimePassed
         minutesLabel.text = String(format: "%02d", Int(passedTime) / 60)
@@ -194,10 +194,10 @@ extension WarmupVC: WarmupViewProtocol {
         pageVC.configure(with: presenter.questions, delegate: self)
     }
 
-    func showResults(with totalTimePassed: Double) {
+    func showResults(with totalTimePassed: Double, resultText: String) {
         navigationItem.setRightBarButtonItems(nil, animated: true)
         completionView.isHidden = false
-        setResults(with: totalTimePassed)
+        setResults(with: totalTimePassed, resultText: resultText)
     }
 
     func updatePassedTime(withMinutes minutes: Int, seconds: Int) {
@@ -215,7 +215,11 @@ extension WarmupVC: WarmupViewProtocol {
     }
 
     func makeResultsSnapshot() -> UIImage? {
-        resultsView.makeSnapshot()
+        // to support possible image transparency, e.g. rounded corners
+        if let data = resultsView.makeSnapshot()?.pngData() {
+            return UIImage(data: data)
+        }
+        return nil
     }
 }
 

--- a/QuizPlease/Modules/WarmUp/WarmupPresenter.swift
+++ b/QuizPlease/Modules/WarmUp/WarmupPresenter.swift
@@ -76,19 +76,26 @@ final class WarmupPresenter: WarmupPresenterProtocol {
 
     func gameEnded() {
         stopTimer()
-        view?.showResults(with: timePassed)
+        view?.showResults(with: timePassed, resultText: makeResultText())
         isGameStarted = false
     }
 
     func shareAction() {
-        if let image = view?.makeResultsSnapshot() {
-            router.showShareSheet(with: image)
-        } else {
+        guard let image = view?.makeResultsSnapshot() else {
             view?.showSimpleAlert(
-                title: "Не удалось поделиться картинкой",
+                title: "Не удалось поделиться результатом разминки",
                 message: "Пожалуйста, попробуйте поделиться ещё раз"
             )
+            return
         }
+
+        let shareText = """
+            Хэй! Я только что прошел разминку от Квиз, плиз! и ответил \(makeResultPrompt())
+            Можете попробовать в приложении.
+            А потом го на игру в бар: \(AppSettings.appStoreUrl)
+            """
+
+        router.showShareSheet(with: [shareText, image])
     }
 
     // MARK: - Private
@@ -118,6 +125,21 @@ final class WarmupPresenter: WarmupPresenterProtocol {
         timer = nil
         let timeElapsed: Double = Date().timeIntervalSince(timestamp) + totalPenaltyTime
         timePassed = timeElapsed
+    }
+
+    private func makeResultPrompt() -> String {
+        let count = questions.count
+        let correct = correctAnswersCount
+        let correctQuestionsPrompt = correct.string(withAssociatedMaleWord: "вопрос")
+        return "правильно на \(correctQuestionsPrompt) из \(count)."
+    }
+
+    private func makeResultText() -> String {
+        """
+        Супер (или нет, вы уж там сами решите)!
+        Вы ответили \(makeResultPrompt())
+        Можно (прям щас) рассказать друзьям.
+        """
     }
 }
 

--- a/QuizPlease/Shared/Models/AppSettings.swift
+++ b/QuizPlease/Shared/Models/AppSettings.swift
@@ -33,6 +33,11 @@ public enum AppSettings {
         URL(string: "https://docs.google.com/document/d/1r5YlaJF5PEgPRrNn0SmrnqHNyzmD_PiM")!
     }()
 
+    /// App's URL on the App Store
+    public static let appStoreUrl: URL = {
+        URL(string: "https://apps.apple.com/ru/app/id1585713090")!
+    }()
+
     public static var isDebug: Bool {
         #if DEBUG
         return true

--- a/QuizPlease/Storyboards/Main.storyboard
+++ b/QuizPlease/Storyboards/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ZoB-p6-6LA">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ZoB-p6-6LA">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
@@ -245,7 +245,7 @@
                                 <color key="separatorColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="ScheduleGameCell" rowHeight="387" id="uUr-s1-kZd" customClass="ScheduleGameCell" customModule="QuizPlease" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.666666030883789" width="390" height="387"/>
+                                        <rect key="frame" x="0.0" y="50" width="390" height="387"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="uUr-s1-kZd" id="Alr-Qi-vba">
                                             <rect key="frame" x="0.0" y="0.0" width="390" height="387"/>
@@ -491,20 +491,20 @@
                                 </prototypes>
                             </tableView>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6ly-LF-rJR">
-                                <rect key="frame" x="0.0" y="88" width="390" height="722"/>
+                                <rect key="frame" x="0.0" y="91" width="390" height="719"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="empty" translatesAutoresizingMaskIntoConstraints="NO" id="552-gI-g13">
-                                        <rect key="frame" x="30" y="170.33333333333331" width="330" height="115"/>
+                                        <rect key="frame" x="30" y="169" width="330" height="115"/>
                                     </imageView>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="Упс! Кажется, сейчас нет игр, на которые открыта регистрация, поэтому пока вы можете размяться или сыграть в наши игры Хоум" textAlignment="center" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pxi-Le-rcS">
-                                        <rect key="frame" x="25" y="315.33333333333331" width="340" height="135.33333333333331"/>
+                                        <rect key="frame" x="25" y="314" width="340" height="135.33333333333337"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <fontDescription key="fontDescription" name="Gilroy-SemiBold" family="Gilroy" pointSize="20"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                     </textView>
                                     <button hidden="YES" opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceRightToLeft" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ooJ-ih-UFn">
-                                        <rect key="frame" x="50" y="470.66666666666663" width="290" height="40"/>
+                                        <rect key="frame" x="50" y="469.33333333333337" width="290" height="40"/>
                                         <color key="backgroundColor" name="themePurple"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="40" id="SEF-Vv-iDx"/>
@@ -714,10 +714,10 @@
                                 <rect key="frame" x="0.0" y="0.0" width="390" height="615"/>
                             </imageView>
                             <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7qy-R2-uOg">
-                                <rect key="frame" x="20" y="133" width="350" height="290"/>
+                                <rect key="frame" x="20" y="136" width="350" height="287"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="..." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="10" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TeC-f4-I5Q">
-                                        <rect key="frame" x="20" y="20" width="305" height="230"/>
+                                        <rect key="frame" x="20" y="20" width="305" height="227"/>
                                         <fontDescription key="fontDescription" name="Gilroy-Medium" family="Gilroy" pointSize="18"/>
                                         <color key="textColor" name="themeGray"/>
                                         <nil key="highlightedColor"/>
@@ -794,13 +794,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Добавление игры" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="20" translatesAutoresizingMaskIntoConstraints="NO" id="jgs-et-DdD">
-                                <rect key="frame" x="60" y="66.666666666666671" width="252" height="29"/>
+                                <rect key="frame" x="60" y="69.666666666666671" width="252" height="29"/>
                                 <fontDescription key="fontDescription" name="Gilroy-Bold" family="Gilroy" pointSize="24"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="G3x-O1-rSK">
-                                <rect key="frame" x="20" y="70" width="20" height="22"/>
+                                <rect key="frame" x="20" y="73" width="20" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="20" id="E7W-tT-Iht"/>
                                 </constraints>
@@ -811,7 +811,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Al5-2C-Wtw">
-                                <rect key="frame" x="328" y="60" width="42" height="42"/>
+                                <rect key="frame" x="328" y="63" width="42" height="42"/>
                                 <color key="backgroundColor" systemColor="systemBlueColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="42" id="V8a-e8-844"/>
@@ -829,20 +829,20 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Сканирование QR-кода" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="20" translatesAutoresizingMaskIntoConstraints="NO" id="dd3-0W-Mzx">
-                                <rect key="frame" x="16" y="225" width="358" height="27"/>
+                                <rect key="frame" x="16" y="226.66666666666666" width="358" height="27"/>
                                 <fontDescription key="fontDescription" name="Gilroy-Bold" family="Gilroy" pointSize="22"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="frames" translatesAutoresizingMaskIntoConstraints="NO" id="Wv1-TK-1r3">
-                                <rect key="frame" x="80" y="312" width="230" height="230"/>
+                                <rect key="frame" x="80" y="313.66666666666669" width="230" height="230.00000000000006"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="Wv1-TK-1r3" secondAttribute="height" multiplier="1:1" id="sQW-LE-6eJ"/>
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Наведите камеру на QR-код" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WSQ-Fw-IK5">
-                                <rect key="frame" x="40" y="602" width="310" height="19.333333333333371"/>
+                                <rect key="frame" x="40" y="603.66666666666663" width="310" height="19.333333333333371"/>
                                 <fontDescription key="fontDescription" name="Gilroy-SemiBold" family="Gilroy" pointSize="16"/>
                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
@@ -884,13 +884,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Ваша игра" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZbQ-1H-6ZY">
-                                <rect key="frame" x="20" y="108" width="350" height="19.333333333333329"/>
+                                <rect key="frame" x="20" y="111" width="350" height="19.333333333333343"/>
                                 <fontDescription key="fontDescription" name="Gilroy-SemiBold" family="Gilroy" pointSize="16"/>
                                 <color key="textColor" systemColor="opaqueSeparatorColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qws-UR-ikk">
-                                <rect key="frame" x="20" y="143.33333333333334" width="350" height="150.00000000000003"/>
+                                <rect key="frame" x="20" y="146.33333333333334" width="350" height="150.00000000000003"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="[кино и музыка]" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="17" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cVs-Oa-se4">
                                         <rect key="frame" x="15.999999999999986" y="16" width="254.66666666666663" height="34"/>
@@ -983,7 +983,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2Ww-pp-CEN" customClass="TitledTextFieldView" customModule="QuizPlease" customModuleProvider="target">
-                                <rect key="frame" x="20" y="309.33333333333331" width="350" height="70"/>
+                                <rect key="frame" x="20" y="312.33333333333331" width="350" height="70"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="arrowDown" translatesAutoresizingMaskIntoConstraints="NO" id="cOy-PU-Jqm">
                                         <rect key="frame" x="318" y="27" width="16" height="16"/>
@@ -1062,7 +1062,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ahH-nd-hl4">
-                                <rect key="frame" x="0.0" y="88" width="390" height="756"/>
+                                <rect key="frame" x="0.0" y="91" width="390" height="753"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gameInfoTemplate" translatesAutoresizingMaskIntoConstraints="NO" id="FKI-MS-LTd">
                                         <rect key="frame" x="0.0" y="0.0" width="390" height="270"/>
@@ -1127,23 +1127,23 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="TmP-N2-jXg">
-                                <rect key="frame" x="0.0" y="158" width="390" height="632"/>
+                                <rect key="frame" x="0.0" y="161" width="390" height="629"/>
                                 <subviews>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalCompressionResistancePriority="751" image="warmupPreview" translatesAutoresizingMaskIntoConstraints="NO" id="MwX-Zk-sSH">
-                                        <rect key="frame" x="7.6666666666666572" y="0.0" width="375" height="250"/>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalCompressionResistancePriority="751" image="warmupPreview" translatesAutoresizingMaskIntoConstraints="NO" id="MwX-Zk-sSH">
+                                        <rect key="frame" x="0.0" y="0.0" width="390" height="250"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="lessThanOrEqual" constant="250" id="a6Y-Cv-faF"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="7" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xve-qv-4fo">
-                                        <rect key="frame" x="20" y="280" width="350" height="262"/>
+                                        <rect key="frame" x="20" y="280" width="350" height="259"/>
                                         <string key="text">Тут будут появляться новые вопросы разминки. Ваша задача — ответить правильно и максимально быстро. В случае неправильного ответа к таймеру добавится 5 секунд.</string>
                                         <fontDescription key="fontDescription" name="Gilroy-Bold" family="Gilroy" pointSize="22"/>
                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hDU-dv-0VE" customClass="ScalingButton" customModule="QuizPlease" customModuleProvider="target">
-                                        <rect key="frame" x="20" y="572" width="350" height="60"/>
+                                        <rect key="frame" x="20" y="569" width="350" height="60"/>
                                         <color key="backgroundColor" name="lightGreen"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="60" id="TKP-ad-yZf"/>
@@ -1170,65 +1170,65 @@
                                 </constraints>
                             </stackView>
                             <containerView hidden="YES" opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yzA-8B-bIa">
-                                <rect key="frame" x="0.0" y="88" width="390" height="702"/>
+                                <rect key="frame" x="0.0" y="91" width="390" height="699"/>
                                 <connections>
                                     <segue destination="JO0-RJ-kRi" kind="embed" identifier="WarmupPageVCEmbedded" id="Vqt-cj-hdd"/>
                                 </connections>
                             </containerView>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dRf-ZR-6Az">
-                                <rect key="frame" x="0.0" y="88" width="390" height="722"/>
+                                <rect key="frame" x="0.0" y="91" width="390" height="719"/>
                                 <subviews>
                                     <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rkO-kp-YWw">
-                                        <rect key="frame" x="20" y="20" width="350" height="602"/>
+                                        <rect key="frame" x="20" y="20" width="350" height="599"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="Oev-C0-R8c">
-                                                <rect key="frame" x="16" y="20" width="318" height="566"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="25" translatesAutoresizingMaskIntoConstraints="NO" id="Oev-C0-R8c">
+                                                <rect key="frame" x="20" y="32" width="310" height="547"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" verticalHuggingPriority="249" image="logoSmall" translatesAutoresizingMaskIntoConstraints="NO" id="29Z-rj-LZY">
-                                                        <rect key="frame" x="16" y="0.0" width="286" height="278.33333333333331"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="310" height="269"/>
                                                         <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     </imageView>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Я прошел разминку Квиз, плиз! и ответил правильно на 8 вопросов из 10" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" minimumFontSize="20" translatesAutoresizingMaskIntoConstraints="NO" id="UJ6-aZ-N8R">
-                                                        <rect key="frame" x="0.0" y="303.33333333333331" width="318" height="126"/>
-                                                        <fontDescription key="fontDescription" name="Gilroy-Bold" family="Gilroy" pointSize="26"/>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Я прошел разминку Квиз, плиз! и ответил правильно на 8 вопросов из 10" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumFontSize="20" translatesAutoresizingMaskIntoConstraints="NO" id="UJ6-aZ-N8R">
+                                                        <rect key="frame" x="0.0" y="294" width="310" height="116.33333333333331"/>
+                                                        <fontDescription key="fontDescription" name="Gilroy-Bold" family="Gilroy" pointSize="24"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" alpha="0.5" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Мой результат" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="15" translatesAutoresizingMaskIntoConstraints="NO" id="KkT-1m-Hff">
-                                                        <rect key="frame" x="83.333333333333329" y="454.33333333333337" width="151.33333333333337" height="26.666666666666686"/>
+                                                        <rect key="frame" x="0.0" y="435.33333333333337" width="310" height="26.666666666666686"/>
                                                         <fontDescription key="fontDescription" name="Gilroy-Bold" family="Gilroy" pointSize="22"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="7mG-oK-DJd">
-                                                        <rect key="frame" x="16" y="506" width="286" height="60"/>
+                                                        <rect key="frame" x="0.0" y="487" width="310" height="60"/>
                                                         <subviews>
                                                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VvR-lk-giY">
-                                                                <rect key="frame" x="0.0" y="0.0" width="83" height="60"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="90" height="60"/>
                                                                 <fontDescription key="fontDescription" name="Gilroy-Bold" family="Gilroy" pointSize="48"/>
                                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" alpha="0.5" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=":" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="P4L-bh-2xL">
-                                                                <rect key="frame" x="83" y="0.0" width="18" height="60"/>
+                                                                <rect key="frame" x="90" y="0.0" width="19.333333333333329" height="60"/>
                                                                 <fontDescription key="fontDescription" name="Gilroy-Bold" family="Gilroy" pointSize="48"/>
                                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qc7-cH-5Vm">
-                                                                <rect key="frame" x="101" y="0.0" width="83" height="60"/>
+                                                                <rect key="frame" x="109.33333333333334" y="0.0" width="90.333333333333343" height="60"/>
                                                                 <fontDescription key="fontDescription" name="Gilroy-Bold" family="Gilroy" pointSize="48"/>
                                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" alpha="0.5" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="," textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GQh-ZD-Z7S">
-                                                                <rect key="frame" x="184" y="0.0" width="19" height="60"/>
+                                                                <rect key="frame" x="199.66666666666666" y="0.0" width="20.333333333333343" height="60"/>
                                                                 <fontDescription key="fontDescription" name="Gilroy-Bold" family="Gilroy" pointSize="48"/>
                                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="00" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsLetterSpacingToFitWidth="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hvg-Wa-lcj">
-                                                                <rect key="frame" x="203" y="0.0" width="83" height="60"/>
+                                                                <rect key="frame" x="220" y="0.0" width="90" height="60"/>
                                                                 <fontDescription key="fontDescription" name="Gilroy-Bold" family="Gilroy" pointSize="48"/>
                                                                 <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <nil key="highlightedColor"/>
@@ -1239,21 +1239,14 @@
                                                         </constraints>
                                                     </stackView>
                                                 </subviews>
-                                                <constraints>
-                                                    <constraint firstItem="29Z-rj-LZY" firstAttribute="leading" secondItem="Oev-C0-R8c" secondAttribute="leading" constant="16" id="2aF-xC-lLU"/>
-                                                    <constraint firstItem="7mG-oK-DJd" firstAttribute="leading" secondItem="Oev-C0-R8c" secondAttribute="leading" constant="16" id="BfZ-qB-ZZg"/>
-                                                    <constraint firstAttribute="trailing" secondItem="UJ6-aZ-N8R" secondAttribute="trailing" id="HAK-7p-U7o"/>
-                                                    <constraint firstItem="UJ6-aZ-N8R" firstAttribute="leading" secondItem="Oev-C0-R8c" secondAttribute="leading" id="Uc5-oC-c14"/>
-                                                    <constraint firstItem="29Z-rj-LZY" firstAttribute="top" secondItem="Oev-C0-R8c" secondAttribute="top" id="jeI-4X-e0S"/>
-                                                </constraints>
                                             </stackView>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemIndigoColor"/>
                                         <constraints>
-                                            <constraint firstItem="Oev-C0-R8c" firstAttribute="top" secondItem="rkO-kp-YWw" secondAttribute="top" constant="20" id="7C6-sJ-csG"/>
-                                            <constraint firstAttribute="trailing" secondItem="Oev-C0-R8c" secondAttribute="trailing" constant="16" id="F6N-5i-Va1"/>
-                                            <constraint firstItem="Oev-C0-R8c" firstAttribute="leading" secondItem="rkO-kp-YWw" secondAttribute="leading" constant="16" id="Q0D-BR-jjf"/>
-                                            <constraint firstAttribute="bottom" secondItem="Oev-C0-R8c" secondAttribute="bottom" constant="16" id="f5e-Sk-Gqp"/>
+                                            <constraint firstItem="Oev-C0-R8c" firstAttribute="top" secondItem="rkO-kp-YWw" secondAttribute="top" constant="32" id="7C6-sJ-csG"/>
+                                            <constraint firstAttribute="trailing" secondItem="Oev-C0-R8c" secondAttribute="trailing" constant="20" id="F6N-5i-Va1"/>
+                                            <constraint firstItem="Oev-C0-R8c" firstAttribute="leading" secondItem="rkO-kp-YWw" secondAttribute="leading" constant="20" id="Q0D-BR-jjf"/>
+                                            <constraint firstAttribute="bottom" secondItem="Oev-C0-R8c" secondAttribute="bottom" constant="20" id="f5e-Sk-Gqp"/>
                                         </constraints>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="number" keyPath="cornerRadiusView">
@@ -1262,7 +1255,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ffs-BV-6gn" customClass="ScalingButton" customModule="QuizPlease" customModuleProvider="target">
-                                        <rect key="frame" x="20" y="642" width="350" height="60"/>
+                                        <rect key="frame" x="20" y="639" width="350" height="60"/>
                                         <color key="backgroundColor" name="lightGreen"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="60" id="Kcp-Az-ugf"/>
@@ -1371,7 +1364,7 @@
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </view>
                                 <view key="tableFooterView" hidden="YES" contentMode="scaleToFill" id="gbU-AV-f8p">
-                                    <rect key="frame" x="0.0" y="292.33333206176758" width="390" height="44"/>
+                                    <rect key="frame" x="0.0" y="303" width="390" height="44"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <subviews>
                                         <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="medium" translatesAutoresizingMaskIntoConstraints="NO" id="QZP-B7-ScY">
@@ -1387,7 +1380,7 @@
                                 </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="RatingCell" rowHeight="85" id="VWG-7n-tdn" customClass="RatingCell" customModule="QuizPlease" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="184.66666603088379" width="390" height="85"/>
+                                        <rect key="frame" x="0.0" y="190" width="390" height="85"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="VWG-7n-tdn" id="yxK-kG-tss">
                                             <rect key="frame" x="0.0" y="0.0" width="390" height="85"/>
@@ -1590,7 +1583,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="QDa-ww-vj0">
-                                <rect key="frame" x="20" y="108" width="350" height="306"/>
+                                <rect key="frame" x="20" y="111" width="350" height="306"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logoSmall" translatesAutoresizingMaskIntoConstraints="NO" id="jhS-3r-YyX">
                                         <rect key="frame" x="0.0" y="0.0" width="350" height="60"/>
@@ -1831,13 +1824,13 @@
                                             <rect key="frame" x="0.0" y="0.0" width="390" height="150"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Загрузка…" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QOB-kX-Edq">
-                                                    <rect key="frame" x="16" y="16" width="358" height="18.666666666666671"/>
+                                                    <rect key="frame" x="16" y="15.999999999999998" width="358" height="19.333333333333329"/>
                                                     <fontDescription key="fontDescription" name="Gilroy-SemiBold" family="Gilroy" pointSize="16"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="-" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="12" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zbv-jy-ImX" customClass="PaddingLabel" customModule="QuizPlease" customModuleProvider="target">
-                                                    <rect key="frame" x="16" y="42.666666666666664" width="110" height="29.999999999999993"/>
+                                                    <rect key="frame" x="16" y="43.333333333333336" width="110" height="30.000000000000007"/>
                                                     <color key="backgroundColor" systemColor="viewFlipsideBackgroundColor"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="110" id="qPP-EH-rVA"/>
@@ -1848,7 +1841,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Здесь все ваши игры и баллы, которые можно потратить на приятности" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" minimumFontSize="14" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dAi-cf-yfW">
-                                                    <rect key="frame" x="16" y="84.666666666666671" width="224" height="49.000000000000014"/>
+                                                    <rect key="frame" x="16" y="85.333333333333329" width="224" height="50.333333333333329"/>
                                                     <fontDescription key="fontDescription" name="Gilroy-SemiBold" family="Gilroy" pointSize="14"/>
                                                     <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
@@ -1857,7 +1850,7 @@
                                                     <rect key="frame" x="254" y="16" width="136" height="174"/>
                                                 </imageView>
                                                 <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pOZ-Rz-FRq">
-                                                    <rect key="frame" x="254" y="89.333333333333329" width="120" height="39.999999999999986"/>
+                                                    <rect key="frame" x="254" y="90.666666666666671" width="120" height="40.000000000000014"/>
                                                     <color key="backgroundColor" name="themePurple"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="120" id="YWj-rr-zNW"/>
@@ -1913,7 +1906,7 @@
                                 </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="ProfileCell" rowHeight="200" id="H5u-zQ-X6z" customClass="ProfileCell" customModule="QuizPlease" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="254.66666603088379" width="390" height="200"/>
+                                        <rect key="frame" x="0.0" y="260" width="390" height="200"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="H5u-zQ-X6z" id="27U-ws-Wrd">
                                             <rect key="frame" x="0.0" y="0.0" width="390" height="200"/>
@@ -1927,13 +1920,13 @@
                                                             <color key="tintColor" name="lemon"/>
                                                         </imageView>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="[кино и музыка]" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="14" adjustsLetterSpacingToFitWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ntf-KH-fTu">
-                                                            <rect key="frame" x="16" y="20" width="205.33333333333334" height="34"/>
+                                                            <rect key="frame" x="16" y="20" width="207.33333333333334" height="34"/>
                                                             <fontDescription key="fontDescription" name="Gilroy-Bold" family="Gilroy" pointSize="28"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="#1000" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dia-4Q-MjH">
-                                                            <rect key="frame" x="264" y="20.666666666666668" width="78" height="32.666666666666657"/>
+                                                            <rect key="frame" x="260.66666666666669" y="20" width="81.333333333333314" height="34"/>
                                                             <fontDescription key="fontDescription" name="Gilroy-Bold" family="Gilroy" pointSize="28"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -2030,7 +2023,7 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="ProfileSampleCell" rowHeight="200" id="CoL-Jo-Hwf" customClass="ProfileSampleCell" customModule="QuizPlease" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="454.66666603088379" width="390" height="200"/>
+                                        <rect key="frame" x="0.0" y="460" width="390" height="200"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="CoL-Jo-Hwf" id="82p-jV-Scm">
                                             <rect key="frame" x="0.0" y="0.0" width="390" height="200"/>
@@ -2142,7 +2135,7 @@
                     <toolbarItems/>
                     <navigationItem key="navigationItem" id="DbJ-DV-xRf"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" backIndicatorImage="backButton" backIndicatorTransitionMaskImage="backButton" id="eis-mF-N6E">
-                        <rect key="frame" x="0.0" y="44" width="390" height="44"/>
+                        <rect key="frame" x="0.0" y="47" width="390" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="tintColor" systemColor="labelColor"/>
                     </navigationBar>
@@ -2164,32 +2157,32 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" alignment="center" spacing="33" translatesAutoresizingMaskIntoConstraints="NO" id="rDR-bR-Cxx">
-                                <rect key="frame" x="0.0" y="88" width="390" height="702"/>
+                                <rect key="frame" x="0.0" y="91" width="390" height="699"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="quizPleaseMecrh" translatesAutoresizingMaskIntoConstraints="NO" id="Pd3-Is-2DR">
-                                        <rect key="frame" x="0.0" y="0.0" width="390" height="277.33333333333331"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="390" height="274.33333333333331"/>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="За игры в Квиз, плиз! вы получаете ништяки" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="16" translatesAutoresizingMaskIntoConstraints="NO" id="eaC-fc-bBn">
-                                        <rect key="frame" x="0.0" y="310.33333333333331" width="390" height="53.333333333333314"/>
+                                        <rect key="frame" x="0.0" y="307.33333333333331" width="390" height="53.333333333333314"/>
                                         <fontDescription key="fontDescription" name="Gilroy-Bold" family="Gilroy" pointSize="22"/>
                                         <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="personKey" translatesAutoresizingMaskIntoConstraints="NO" id="7zY-Cm-1L3">
-                                        <rect key="frame" x="170" y="396.66666666666669" width="50" height="50"/>
+                                        <rect key="frame" x="170" y="393.66666666666669" width="50" height="50"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="50" id="C6y-yx-8Ay"/>
                                             <constraint firstAttribute="height" constant="50" id="nKd-HM-ryC"/>
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Авторизация / Регистрация" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nk3-Od-0yS">
-                                        <rect key="frame" x="0.0" y="479.66666666666663" width="390" height="19.333333333333314"/>
+                                        <rect key="frame" x="0.0" y="476.66666666666663" width="390" height="19.333333333333314"/>
                                         <fontDescription key="fontDescription" name="Gilroy-SemiBold" family="Gilroy" pointSize="16"/>
                                         <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RLJ-3L-P4p" customClass="PhoneTextFieldView" customModule="QuizPlease" customModuleProvider="target">
-                                        <rect key="frame" x="20" y="532" width="350" height="77"/>
+                                        <rect key="frame" x="20" y="529" width="350" height="77"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="77" id="kiV-ui-NFn"/>
@@ -2199,7 +2192,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Q9T-Y2-fsH" customClass="ScalingButton" customModule="QuizPlease" customModuleProvider="target">
-                                        <rect key="frame" x="20" y="642" width="350" height="60"/>
+                                        <rect key="frame" x="20" y="639" width="350" height="60"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="60" id="5lb-Oi-nti"/>
@@ -2271,7 +2264,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="aTk-QU-tXA" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="ftx-3d-9Jt">
-                        <rect key="frame" x="0.0" y="44" width="390" height="44"/>
+                        <rect key="frame" x="0.0" y="47" width="390" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -2374,7 +2367,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="grr-9p-KeR" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="aJu-UF-Zb6">
-                        <rect key="frame" x="0.0" y="44" width="390" height="44"/>
+                        <rect key="frame" x="0.0" y="47" width="390" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -2398,7 +2391,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                             </imageView>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="logoSmall" translatesAutoresizingMaskIntoConstraints="NO" id="hGr-D6-WPf">
-                                <rect key="frame" x="75" y="267" width="240" height="240"/>
+                                <rect key="frame" x="75" y="268.66666666666669" width="240" height="240"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="hGr-D6-WPf" secondAttribute="height" multiplier="1:1" id="CTR-Zs-aeE"/>
@@ -2411,7 +2404,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="large" translatesAutoresizingMaskIntoConstraints="NO" id="yd5-bC-OD4">
-                                <rect key="frame" x="176.66666666666666" y="607" width="37" height="37"/>
+                                <rect key="frame" x="176.66666666666666" y="608.66666666666663" width="37" height="37"/>
                                 <color key="color" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </activityIndicatorView>
                         </subviews>
@@ -2505,13 +2498,13 @@
             <color red="0.38823529411764707" green="0.31372549019607843" blue="0.92156862745098034" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="opaqueSeparatorColor">
             <color red="0.77647058823529413" green="0.77647058823529413" blue="0.78431372549019607" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="placeholderTextColor">
-            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.29803921568627451" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="scrollViewTexturedBackgroundColor">
             <color red="0.43529411764705878" green="0.44313725490196082" blue="0.47450980392156861" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
* Share text with App Store link + results image (image now has transparency in rounded corners)
* Change results text
* Once again change results view layout