### PR TITLE
Add several build configurations and schemes

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -14,9 +14,20 @@ target 'QuizPlease' do
     :git => 'https://git.yoomoney.ru/scm/sdk/yookassa-payments-swift.git',
     :tag => '6.8.2'
 
-  pod 'Wormholy', :configurations => ['Debug']
+  pod 'Wormholy', :configurations => ['Staging', 'Debug']
+
+  target 'QuizPleaseTests' do
+    inherit! :complete
+    # Pods for testing
+  end
 
 end
+
+project 'QuizPlease', {
+  'Production' => :release, 
+  'Staging' => :release,
+  'Debug' => :debug
+}
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|

--- a/QuizPlease.xcodeproj/project.pbxproj
+++ b/QuizPlease.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		44461018673EE50E25492D87 /* Pods_QuizPlease_QuizPleaseTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7CDEF38011787C6A59A13C3C /* Pods_QuizPlease_QuizPleaseTests.framework */; };
 		4DF0586D2E5AA5937395870F /* Pods_QuizPlease.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A4D9180E261A72F900C4D51E /* Pods_QuizPlease.framework */; };
 		A400A26E269CE4C200FBF70C /* String+WordBuilding.swift in Sources */ = {isa = PBXBuildFile; fileRef = A400A26D269CE4C200FBF70C /* String+WordBuilding.swift */; };
 		A405C98724F651C900C74787 /* MainMenuShopCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A405C98624F651C900C74787 /* MainMenuShopCollectionView.swift */; };
@@ -82,6 +83,8 @@
 		A42F00E028F237A300184E54 /* URLComponents+QueryDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A42F00DF28F237A300184E54 /* URLComponents+QueryDictionary.swift */; };
 		A4317731267BEEEE0062E0E0 /* SpecialCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4317730267BEEEE0062E0E0 /* SpecialCondition.swift */; };
 		A4323FC828A01A8E001D1C4B /* UIAlertController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4323FC728A01A8E001D1C4B /* UIAlertController+Extensions.swift */; };
+		A43249F329DF844800DEE6C1 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43249F229DF844800DEE6C1 /* Configuration.swift */; };
+		A43249F529DF888100DEE6C1 /* Configuration+ConvenientProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43249F429DF888100DEE6C1 /* Configuration+ConvenientProperties.swift */; };
 		A4358951265528D400B54C89 /* LoadingIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4358950265528D400B54C89 /* LoadingIndicator.swift */; };
 		A43DB6AF254770F8006E4569 /* ActivityIndicator+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43DB6AE254770F8006E4569 /* ActivityIndicator+Extensions.swift */; };
 		A43E0AD9258E2F3400207616 /* UIEdgeInsets+Init.swift in Sources */ = {isa = PBXBuildFile; fileRef = A43E0AD8258E2F3400207616 /* UIEdgeInsets+Init.swift */; };
@@ -347,8 +350,13 @@
 /* Begin PBXFileReference section */
 		0D0A5F91BB7CF8490B968FAF /* Pods-QuizPleaseTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuizPleaseTests.release.xcconfig"; path = "Target Support Files/Pods-QuizPleaseTests/Pods-QuizPleaseTests.release.xcconfig"; sourceTree = "<group>"; };
 		141F5DF1E05B9C0BE750DC53 /* Pods-QuizPlease.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuizPlease.release.xcconfig"; path = "Target Support Files/Pods-QuizPlease/Pods-QuizPlease.release.xcconfig"; sourceTree = "<group>"; };
+		16DC219F6CAE5CBB90DAAF03 /* Pods-QuizPlease-QuizPleaseTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuizPlease-QuizPleaseTests.staging.xcconfig"; path = "Target Support Files/Pods-QuizPlease-QuizPleaseTests/Pods-QuizPlease-QuizPleaseTests.staging.xcconfig"; sourceTree = "<group>"; };
+		30D99B3DFBAFE3F6A1C9CBD5 /* Pods-QuizPlease.production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuizPlease.production.xcconfig"; path = "Target Support Files/Pods-QuizPlease/Pods-QuizPlease.production.xcconfig"; sourceTree = "<group>"; };
 		463DA29CC431986A33D73FEE /* Pods-QuizPlease.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuizPlease.debug.xcconfig"; path = "Target Support Files/Pods-QuizPlease/Pods-QuizPlease.debug.xcconfig"; sourceTree = "<group>"; };
 		4B96AC7846537ADF1B2E29E1 /* Pods_QuizPlease.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_QuizPlease.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5B0D3BDCD9BD4D8A2792F64D /* Pods-QuizPlease-QuizPleaseTests.production.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuizPlease-QuizPleaseTests.production.xcconfig"; path = "Target Support Files/Pods-QuizPlease-QuizPleaseTests/Pods-QuizPlease-QuizPleaseTests.production.xcconfig"; sourceTree = "<group>"; };
+		6637A838D525920CEAF0884D /* Pods-QuizPlease.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuizPlease.staging.xcconfig"; path = "Target Support Files/Pods-QuizPlease/Pods-QuizPlease.staging.xcconfig"; sourceTree = "<group>"; };
+		7CDEF38011787C6A59A13C3C /* Pods_QuizPlease_QuizPleaseTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_QuizPlease_QuizPleaseTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A400A26D269CE4C200FBF70C /* String+WordBuilding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+WordBuilding.swift"; sourceTree = "<group>"; };
 		A405C98624F651C900C74787 /* MainMenuShopCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenuShopCollectionView.swift; sourceTree = "<group>"; };
 		A40689F824F7D11A001273B2 /* City.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = City.swift; sourceTree = "<group>"; };
@@ -421,9 +429,14 @@
 		A42F00DF28F237A300184E54 /* URLComponents+QueryDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLComponents+QueryDictionary.swift"; sourceTree = "<group>"; };
 		A4317730267BEEEE0062E0E0 /* SpecialCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpecialCondition.swift; sourceTree = "<group>"; };
 		A4323FC728A01A8E001D1C4B /* UIAlertController+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIAlertController+Extensions.swift"; sourceTree = "<group>"; };
+		A43249F229DF844800DEE6C1 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
+		A43249F429DF888100DEE6C1 /* Configuration+ConvenientProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Configuration+ConvenientProperties.swift"; sourceTree = "<group>"; };
 		A4358950265528D400B54C89 /* LoadingIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingIndicator.swift; sourceTree = "<group>"; };
 		A4361BD2262A0D70002A7B55 /* TMXProfilingConnections.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = TMXProfilingConnections.xcframework; path = Frameworks/TMXProfilingConnections.xcframework; sourceTree = "<group>"; };
 		A4361BD3262A0D70002A7B55 /* TMXProfiling.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = TMXProfiling.xcframework; path = Frameworks/TMXProfiling.xcframework; sourceTree = "<group>"; };
+		A43D154629DF32BE0065FE2F /* Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Base.xcconfig; sourceTree = "<group>"; };
+		A43D154729DF342A0065FE2F /* Staging.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Staging.xcconfig; sourceTree = "<group>"; };
+		A43D154829DF34320065FE2F /* Production.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Production.xcconfig; sourceTree = "<group>"; };
 		A43DB6AE254770F8006E4569 /* ActivityIndicator+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ActivityIndicator+Extensions.swift"; sourceTree = "<group>"; };
 		A43E0AD8258E2F3400207616 /* UIEdgeInsets+Init.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIEdgeInsets+Init.swift"; sourceTree = "<group>"; };
 		A44084F9269B07E6005F2ED0 /* TwoColumnsFlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoColumnsFlowLayout.swift; sourceTree = "<group>"; };
@@ -589,6 +602,7 @@
 		A4C71765254DE61600898CA5 /* YooMoneyPaymentProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YooMoneyPaymentProvider.swift; sourceTree = "<group>"; };
 		A4C71768254E016400898CA5 /* PaymentProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentProvider.swift; sourceTree = "<group>"; };
 		A4C9D81224EA78BB00523688 /* RatingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RatingCell.swift; sourceTree = "<group>"; };
+		A4CA4FFA29DF7F8E00EAD40A /* Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		A4CC5FC024DACE0E0042B41C /* ShopInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopInteractor.swift; sourceTree = "<group>"; };
 		A4CC5FC224DACE1A0042B41C /* ShopPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopPresenter.swift; sourceTree = "<group>"; };
 		A4CC5FC424DACE230042B41C /* ShopRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShopRouter.swift; sourceTree = "<group>"; };
@@ -675,6 +689,7 @@
 		A4FFA4AC24F3AE78006A1150 /* MKMapView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MKMapView+Extensions.swift"; sourceTree = "<group>"; };
 		A4FFA4AE24F3BD73006A1150 /* RegisterForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterForm.swift; sourceTree = "<group>"; };
 		A4FFA4B024F3BE2A006A1150 /* PaymentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentType.swift; sourceTree = "<group>"; };
+		BC35E36B4EC1AC7E87582913 /* Pods-QuizPlease-QuizPleaseTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuizPlease-QuizPleaseTests.debug.xcconfig"; path = "Target Support Files/Pods-QuizPlease-QuizPleaseTests/Pods-QuizPlease-QuizPleaseTests.debug.xcconfig"; sourceTree = "<group>"; };
 		CE79ED1DF5B83236FD6617CA /* libPods-QuizPleaseTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-QuizPleaseTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD165C45138E9C7592ABD3A5 /* Pods-QuizPleaseTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuizPleaseTests.debug.xcconfig"; path = "Target Support Files/Pods-QuizPleaseTests/Pods-QuizPleaseTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -700,6 +715,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				44461018673EE50E25492D87 /* Pods_QuizPlease_QuizPleaseTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -714,6 +730,7 @@
 				A4D9180E261A72F900C4D51E /* Pods_QuizPlease.framework */,
 				4B96AC7846537ADF1B2E29E1 /* Pods_QuizPlease.framework */,
 				CE79ED1DF5B83236FD6617CA /* libPods-QuizPleaseTests.a */,
+				7CDEF38011787C6A59A13C3C /* Pods_QuizPlease_QuizPleaseTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -767,6 +784,7 @@
 			isa = PBXGroup;
 			children = (
 				A4A7E6AB2533C82A00F86947 /* QuizPlease.entitlements */,
+				A43D154529DF329E0065FE2F /* Config */,
 				A40D816D24D2C73D006D2CE3 /* AppDelegates */,
 				A4BA1CF124D83A6900D32ADC /* Modules */,
 				A40D818C24D2E3DB006D2CE3 /* Services */,
@@ -950,6 +968,7 @@
 				A42F00DF28F237A300184E54 /* URLComponents+QueryDictionary.swift */,
 				A4C3C44829CD03CB00DB0364 /* UIStoryboard+Main.swift */,
 				A4C3C44A29CD061F00DB0364 /* UIWindow+SetRootController.swift */,
+				A43249F429DF888100DEE6C1 /* Configuration+ConvenientProperties.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -985,6 +1004,17 @@
 				A4317730267BEEEE0062E0E0 /* SpecialCondition.swift */,
 			);
 			path = Entity;
+			sourceTree = "<group>";
+		};
+		A43D154529DF329E0065FE2F /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				A43D154629DF32BE0065FE2F /* Base.xcconfig */,
+				A4CA4FFA29DF7F8E00EAD40A /* Debug.xcconfig */,
+				A43D154729DF342A0065FE2F /* Staging.xcconfig */,
+				A43D154829DF34320065FE2F /* Production.xcconfig */,
+			);
+			path = Config;
 			sourceTree = "<group>";
 		};
 		A445E34624DE02A20070B9FC /* View */ = {
@@ -1609,6 +1639,7 @@
 				A4D44A2428D1397B004703B4 /* JsonDecoder.swift */,
 				A4D44A2628D139EF004703B4 /* AsyncExecutor.swift */,
 				A4E4400728E901A900514C0D /* CoreAssembly.swift */,
+				A43249F229DF844800DEE6C1 /* Configuration.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1757,6 +1788,11 @@
 				141F5DF1E05B9C0BE750DC53 /* Pods-QuizPlease.release.xcconfig */,
 				DD165C45138E9C7592ABD3A5 /* Pods-QuizPleaseTests.debug.xcconfig */,
 				0D0A5F91BB7CF8490B968FAF /* Pods-QuizPleaseTests.release.xcconfig */,
+				6637A838D525920CEAF0884D /* Pods-QuizPlease.staging.xcconfig */,
+				30D99B3DFBAFE3F6A1C9CBD5 /* Pods-QuizPlease.production.xcconfig */,
+				16DC219F6CAE5CBB90DAAF03 /* Pods-QuizPlease-QuizPleaseTests.staging.xcconfig */,
+				5B0D3BDCD9BD4D8A2792F64D /* Pods-QuizPlease-QuizPleaseTests.production.xcconfig */,
+				BC35E36B4EC1AC7E87582913 /* Pods-QuizPlease-QuizPleaseTests.debug.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -1797,9 +1833,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = A44E5EE8295EFCA700402B97 /* Build configuration list for PBXNativeTarget "QuizPleaseTests" */;
 			buildPhases = (
+				BE16BCFDE698052361F896C4 /* [CP] Check Pods Manifest.lock */,
 				A44E5EDE295EFCA700402B97 /* Sources */,
 				A44E5EDF295EFCA700402B97 /* Frameworks */,
 				A44E5EE0295EFCA700402B97 /* Resources */,
+				61B5E4B31AB9A2A233C21AEC /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -1951,6 +1989,23 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
+		61B5E4B31AB9A2A233C21AEC /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-QuizPlease-QuizPleaseTests/Pods-QuizPlease-QuizPleaseTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-QuizPlease-QuizPleaseTests/Pods-QuizPlease-QuizPleaseTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-QuizPlease-QuizPleaseTests/Pods-QuizPlease-QuizPleaseTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		A43868DA2871CC54004031AF /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -1967,6 +2022,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftlint > /dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+		BE16BCFDE698052361F896C4 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-QuizPlease-QuizPleaseTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -2125,6 +2202,7 @@
 				A4A13E6C2698754800B3A499 /* PaymentOptions.swift in Sources */,
 				A4C71766254DE61600898CA5 /* YooMoneyPaymentProvider.swift in Sources */,
 				A4C3C44729CCECD800DB0364 /* WelcomeRouter.swift in Sources */,
+				A43249F529DF888100DEE6C1 /* Configuration+ConvenientProperties.swift in Sources */,
 				A40D818A24D2D24C006D2CE3 /* ScheduleCell.swift in Sources */,
 				A46F303A24F52CAE0062A333 /* GameOnlinePaymentCell.swift in Sources */,
 				A4FEB057273739F10052AD7B /* MapProvider.swift in Sources */,
@@ -2168,6 +2246,7 @@
 				A4F234802685E0D200E6FC68 /* AnyCodable.swift in Sources */,
 				A4F0B9D426246EB100E4E2A5 /* NetworkConfiguration.swift in Sources */,
 				A48E2FC425335A9500CD6BE6 /* SavedAuthInfo.swift in Sources */,
+				A43249F329DF844800DEE6C1 /* Configuration.swift in Sources */,
 				A40689F924F7D11A001273B2 /* City.swift in Sources */,
 				A472D29825288F0800AA9906 /* AuthInfoResponse.swift in Sources */,
 				A45241DE265479A70058285C /* CGRect+setHeight.swift in Sources */,
@@ -2299,8 +2378,125 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		A40D816824D2C6C2006D2CE3 /* Debug */ = {
+		A43D154C29DF35C60065FE2F /* Production */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = A43D154629DF32BE0065FE2F /* Base.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Production;
+		};
+		A43D154D29DF35C60065FE2F /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A43D154829DF34320065FE2F /* Production.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = QuizPlease/QuizPlease.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 40;
+				DEVELOPMENT_TEAM = 5524GP5G24;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/Frameworks",
+				);
+				INFOPLIST_FILE = QuizPlease/PropertyLists/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.2;
+				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.quizplease.app;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Production;
+		};
+		A43D154E29DF35C60065FE2F /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 5B0D3BDCD9BD4D8A2792F64D /* Pods-QuizPlease-QuizPleaseTests.production.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5524GP5G24;
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${SRCROOT}/Pods/Firebase/CoreOnly/Sources",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.quizplease.QuizPleaseTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/QuizPlease.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/QuizPlease";
+			};
+			name = Production;
+		};
+		A4CA4FFB29DF7FDB00EAD40A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A43D154629DF32BE0065FE2F /* Base.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
@@ -2361,8 +2557,67 @@
 			};
 			name = Debug;
 		};
-		A40D816924D2C6C2006D2CE3 /* Release */ = {
+		A4CA4FFC29DF7FDB00EAD40A /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = A4CA4FFA29DF7F8E00EAD40A /* Debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = QuizPlease/QuizPlease.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 40;
+				DEVELOPMENT_TEAM = 5524GP5G24;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+					"$(PROJECT_DIR)/Frameworks",
+				);
+				INFOPLIST_FILE = QuizPlease/PropertyLists/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0.2;
+				PRODUCT_BUNDLE_IDENTIFIER = com.quizplease.app;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		A4CA4FFD29DF7FDB00EAD40A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = BC35E36B4EC1AC7E87582913 /* Pods-QuizPlease-QuizPleaseTests.debug.xcconfig */;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 5524GP5G24;
+				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${SRCROOT}/Pods/Firebase/CoreOnly/Sources",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.quizplease.QuizPleaseTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/QuizPlease.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/QuizPlease";
+			};
+			name = Debug;
+		};
+		A4CA4FFE29DF809000EAD40A /* Staging */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A43D154629DF32BE0065FE2F /* Base.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
@@ -2415,44 +2670,11 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 				VALIDATE_PRODUCT = YES;
 			};
-			name = Release;
+			name = Staging;
 		};
-		A40D816B24D2C6C2006D2CE3 /* Debug */ = {
+		A4CA4FFF29DF809000EAD40A /* Staging */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 463DA29CC431986A33D73FEE /* Pods-QuizPlease.debug.xcconfig */;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_ENTITLEMENTS = QuizPlease/QuizPlease.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 40;
-				DEVELOPMENT_TEAM = 5524GP5G24;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(PROJECT_DIR)",
-					"$(PROJECT_DIR)/Frameworks",
-				);
-				INFOPLIST_FILE = QuizPlease/PropertyLists/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				MARKETING_VERSION = 1.0.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.quizplease.app;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
-			};
-			name = Debug;
-		};
-		A40D816C24D2C6C2006D2CE3 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 141F5DF1E05B9C0BE750DC53 /* Pods-QuizPlease.release.xcconfig */;
+			baseConfigurationReference = A43D154729DF342A0065FE2F /* Staging.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = QuizPlease/QuizPlease.entitlements;
@@ -2482,10 +2704,11 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 			};
-			name = Release;
+			name = Staging;
 		};
-		A44E5EE9295EFCA700402B97 /* Debug */ = {
+		A4CA500029DF809000EAD40A /* Staging */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 16DC219F6CAE5CBB90DAAF03 /* Pods-QuizPlease-QuizPleaseTests.staging.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
@@ -2493,7 +2716,10 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 5524GP5G24;
 				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = "${SRCROOT}/Pods/Firebase/CoreOnly/Sources";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"${SRCROOT}/Pods/Firebase/CoreOnly/Sources",
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.quizplease.QuizPleaseTests;
@@ -2503,28 +2729,7 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/QuizPlease.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/QuizPlease";
 			};
-			name = Debug;
-		};
-		A44E5EEA295EFCA700402B97 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				BUNDLE_LOADER = "$(TEST_HOST)";
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 5524GP5G24;
-				GENERATE_INFOPLIST_FILE = YES;
-				HEADER_SEARCH_PATHS = "${SRCROOT}/Pods/Firebase/CoreOnly/Sources";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.quizplease.QuizPleaseTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/QuizPlease.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/QuizPlease";
-			};
-			name = Release;
+			name = Staging;
 		};
 /* End XCBuildConfiguration section */
 
@@ -2532,29 +2737,32 @@
 		A40D815124D2C6C1006D2CE3 /* Build configuration list for PBXProject "QuizPlease" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A40D816824D2C6C2006D2CE3 /* Debug */,
-				A40D816924D2C6C2006D2CE3 /* Release */,
+				A4CA4FFB29DF7FDB00EAD40A /* Debug */,
+				A43D154C29DF35C60065FE2F /* Production */,
+				A4CA4FFE29DF809000EAD40A /* Staging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		A40D816A24D2C6C2006D2CE3 /* Build configuration list for PBXNativeTarget "QuizPlease" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A40D816B24D2C6C2006D2CE3 /* Debug */,
-				A40D816C24D2C6C2006D2CE3 /* Release */,
+				A4CA4FFC29DF7FDB00EAD40A /* Debug */,
+				A43D154D29DF35C60065FE2F /* Production */,
+				A4CA4FFF29DF809000EAD40A /* Staging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 		A44E5EE8295EFCA700402B97 /* Build configuration list for PBXNativeTarget "QuizPleaseTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				A44E5EE9295EFCA700402B97 /* Debug */,
-				A44E5EEA295EFCA700402B97 /* Release */,
+				A4CA4FFD29DF7FDB00EAD40A /* Debug */,
+				A43D154E29DF35C60065FE2F /* Production */,
+				A4CA500029DF809000EAD40A /* Staging */,
 			);
 			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
+			defaultConfigurationName = Production;
 		};
 /* End XCConfigurationList section */
 

--- a/QuizPlease.xcodeproj/xcshareddata/xcschemes/QuizPlease Debug.xcscheme
+++ b/QuizPlease.xcodeproj/xcshareddata/xcschemes/QuizPlease Debug.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:QuizPlease.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A44E5EE1295EFCA700402B97"
+               BuildableName = "QuizPleaseTests.xctest"
+               BlueprintName = "QuizPleaseTests"
+               ReferencedContainer = "container:QuizPlease.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -29,8 +43,7 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
-            skipped = "NO"
-            parallelizable = "YES">
+            skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "A44E5EE1295EFCA700402B97"
@@ -63,7 +76,7 @@
       </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Production"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
@@ -83,7 +96,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/QuizPlease.xcodeproj/xcshareddata/xcschemes/QuizPlease Production.xcscheme
+++ b/QuizPlease.xcodeproj/xcshareddata/xcschemes/QuizPlease Production.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.8">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A40D815524D2C6C1006D2CE3"
+               BuildableName = "QuizPlease.app"
+               BlueprintName = "QuizPlease"
+               ReferencedContainer = "container:QuizPlease.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Production"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Production"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A40D815524D2C6C1006D2CE3"
+            BuildableName = "QuizPlease.app"
+            BlueprintName = "QuizPlease"
+            ReferencedContainer = "container:QuizPlease.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Production"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A40D815524D2C6C1006D2CE3"
+            BuildableName = "QuizPlease.app"
+            BlueprintName = "QuizPlease"
+            ReferencedContainer = "container:QuizPlease.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Production">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Production"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/QuizPlease.xcodeproj/xcshareddata/xcschemes/QuizPlease Staging.xcscheme
+++ b/QuizPlease.xcodeproj/xcshareddata/xcschemes/QuizPlease Staging.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1340"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A40D815524D2C6C1006D2CE3"
+               BuildableName = "QuizPlease.app"
+               BlueprintName = "QuizPlease"
+               ReferencedContainer = "container:QuizPlease.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Staging"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Staging"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = "en"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A40D815524D2C6C1006D2CE3"
+            BuildableName = "QuizPlease.app"
+            BlueprintName = "QuizPlease"
+            ReferencedContainer = "container:QuizPlease.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Staging"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A40D815524D2C6C1006D2CE3"
+            BuildableName = "QuizPlease.app"
+            BlueprintName = "QuizPlease"
+            ReferencedContainer = "container:QuizPlease.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Staging">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Staging"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/QuizPlease.xcodeproj/xcshareddata/xcschemes/QuizPleaseTests.xcscheme
+++ b/QuizPlease.xcodeproj/xcshareddata/xcschemes/QuizPleaseTests.xcscheme
@@ -37,7 +37,7 @@
       allowLocationSimulation = "YES">
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
@@ -47,7 +47,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>

--- a/QuizPlease/Config/Base.xcconfig
+++ b/QuizPlease/Config/Base.xcconfig
@@ -1,0 +1,12 @@
+//
+//  Base.xcconfig
+//  QuizPlease
+//
+//  Created by Владислав on 06.04.2023.
+//  Copyright © 2023 Владислав. All rights reserved.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+APP_NAME = Квиз, плиз!

--- a/QuizPlease/Config/Debug.xcconfig
+++ b/QuizPlease/Config/Debug.xcconfig
@@ -1,0 +1,12 @@
+//
+//  Debug.xcconfig
+//  QuizPlease
+//
+//  Created by Владислав on 07.04.2023.
+//  Copyright © 2023 Владислав. All rights reserved.
+//
+
+#include "Base.xcconfig"
+#include "Pods/Target Support Files/Pods-QuizPlease/Pods-QuizPlease.debug.xcconfig"
+
+APP_NAME = $(inherited) Dev

--- a/QuizPlease/Config/Production.xcconfig
+++ b/QuizPlease/Config/Production.xcconfig
@@ -1,0 +1,10 @@
+//
+//  Production.xcconfig
+//  QuizPlease
+//
+//  Created by Владислав on 06.04.2023.
+//  Copyright © 2023 Владислав. All rights reserved.
+//
+
+#include "Base.xcconfig"
+#include "Pods/Target Support Files/Pods-QuizPlease/Pods-QuizPlease.production.xcconfig"

--- a/QuizPlease/Config/Staging.xcconfig
+++ b/QuizPlease/Config/Staging.xcconfig
@@ -1,0 +1,12 @@
+//
+//  Staging.xcconfig
+//  QuizPlease
+//
+//  Created by Владислав on 06.04.2023.
+//  Copyright © 2023 Владислав. All rights reserved.
+//
+
+#include "Base.xcconfig"
+#include "Pods/Target Support Files/Pods-QuizPlease/Pods-QuizPlease.staging.xcconfig"
+
+APP_NAME = $(inherited) Staging

--- a/QuizPlease/Core/Configuration.swift
+++ b/QuizPlease/Core/Configuration.swift
@@ -1,0 +1,33 @@
+//
+//  Configuration.swift
+//  QuizPlease
+//
+//  Created by Владислав on 07.04.2023.
+//  Copyright © 2023 Владислав. All rights reserved.
+//
+
+import Foundation
+
+/// App configuration
+public enum Configuration: String {
+
+    /// Development configuration
+    case debug
+    /// Testing configuration
+    case staging
+    /// Release configuration
+    case production
+
+    /// Сonfiguration in which the App is currently running
+    public static let current: Configuration = {
+        guard let rawValue = Bundle.main.infoDictionary?["Configuration"] as? String else {
+            fatalError("No Configuration Found")
+        }
+
+        guard let configuration = Configuration(rawValue: rawValue.lowercased()) else {
+            fatalError("Invalid Configuration")
+        }
+
+        return configuration
+    }()
+}

--- a/QuizPlease/Core/Transitions/Applinks/ApplinkRouter.swift
+++ b/QuizPlease/Core/Transitions/Applinks/ApplinkRouter.swift
@@ -113,13 +113,12 @@ final class ApplinkRouterImpl: ApplinkRouter {
     }
 
     private func showDebugAlert(title: String) {
-        #if DEBUG
+        guard !Configuration.current.isProduction else { return }
         // present error alert
         guard let topVc = UIApplication.shared.getKeyWindow()?.topViewController else { return }
         let linkDescription = pendingLink.map { String(describing: $0) } ?? "null"
         let keys = endpointsDictionary.keys.map { String($0) }
         let validEndpointsIds = "Valid enpoint identifiers: \(keys)"
         topVc.showSimpleAlert(title: title, message: "Link: \(linkDescription),\n\n\(validEndpointsIds)")
-        #endif
     }
 }

--- a/QuizPlease/Extensions/Configuration+ConvenientProperties.swift
+++ b/QuizPlease/Extensions/Configuration+ConvenientProperties.swift
@@ -1,0 +1,22 @@
+//
+//  Configuration+ConvenientProperties.swift
+//  QuizPlease
+//
+//  Created by Владислав on 07.04.2023.
+//  Copyright © 2023 Владислав. All rights reserved.
+//
+
+import Foundation
+
+public extension Configuration {
+
+    /// Convenient property to check for Debug
+    var isDebug: Bool {
+        self == .debug
+    }
+
+    /// Convenient property to check for Production
+    var isProduction: Bool {
+        self == .production
+    }
+}

--- a/QuizPlease/Extensions/UIApplication/UIApplication+debugInfo.swift
+++ b/QuizPlease/Extensions/UIApplication/UIApplication+debugInfo.swift
@@ -12,9 +12,8 @@ extension UIApplication {
 
     var debugInfo: String {
         let appVersionString = Bundle.main.version
-        let buildKind = AppSettings.isDebug ? "Debug" : "Release"
         return """
-        AppVersion: \(buildKind) \(appVersionString)
+        AppVersion: \(Configuration.current) \(appVersionString)
         \(AppSettings.description)
         \(NetworkConfiguration.standard)
         """

--- a/QuizPlease/Modules/GameOrder/GameOrderPresenter.swift
+++ b/QuizPlease/Modules/GameOrder/GameOrderPresenter.swift
@@ -54,6 +54,7 @@ protocol GameOrderPresenterProtocol {
     func didChangeComment(_ comment: String)
 }
 
+// MARK: ❗️ TODO: Fix type body length
 // swiftlint:disable type_body_length
 final class GameOrderPresenter: GameOrderPresenterProtocol {
 

--- a/QuizPlease/Modules/GameOrder/View/GameOrderVC.swift
+++ b/QuizPlease/Modules/GameOrder/View/GameOrderVC.swift
@@ -270,7 +270,7 @@ extension GameOrderVC: GameOrderViewProtocol {
         ) { [weak self] image in
             guard let self = self else { return }
             if image == nil {
-                self.gameImageView.loadImage(using: .prod, path: path, placeholderImage: placeholder)
+                self.gameImageView.loadImage(using: .production, path: path, placeholderImage: placeholder)
             }
         }
     }

--- a/QuizPlease/Modules/HomeGame/Model/HomeGame.swift
+++ b/QuizPlease/Modules/HomeGame/Model/HomeGame.swift
@@ -35,7 +35,7 @@ struct HomeGame: Decodable {
 extension HomeGame {
     var videoUrl: URL? {
         let path = videos_link ?? ""
-        var components = URLComponents(string: NetworkConfiguration.prod.host)!
+        var components = URLComponents(string: NetworkConfiguration.production.host)!
         components.path = path.pathProof
         return components.url
     }

--- a/QuizPlease/Modules/MainMenu/MainMenuPresenter.swift
+++ b/QuizPlease/Modules/MainMenu/MainMenuPresenter.swift
@@ -107,7 +107,7 @@ final class MainMenuPresenter: MainMenuPresenterProtocol {
     }
 
     func didLongTapOnLogo() {
-        guard AppSettings.isDebug else { return }
+        guard !Configuration.current.isProduction else { return }
         let pStyle = NSMutableParagraphStyle()
         pStyle.alignment = .left
         let font: UIFont

--- a/QuizPlease/Modules/Rating/View/RatingCell.swift
+++ b/QuizPlease/Modules/Rating/View/RatingCell.swift
@@ -31,6 +31,6 @@ final class RatingCell: UITableViewCell, IdentifiableType {
         teamNameLabel.text = team
         gamesPlayedLabel.text = games.string(withAssociatedFirstCaseWord: "игра", changingCase: .nominative)
         pointsScoredLabel.text = points.string(withAssociatedMaleWord: "балл")
-        teamImageView.loadImage(using: .prod, path: imagePath)
+        teamImageView.loadImage(using: .production, path: imagePath)
     }
 }

--- a/QuizPlease/Modules/WarmUp/WarmupConfigurator.swift
+++ b/QuizPlease/Modules/WarmUp/WarmupConfigurator.swift
@@ -15,11 +15,11 @@ final class WarmupConfigurator: Configurator {
     func configure(_ view: WarmupViewProtocol) {
         let enableWarmupQuestionsSerivceStubInDebug = true
         let interactor = WarmupInteractor(
-            questionsService: AppSettings.isDebug && enableWarmupQuestionsSerivceStubInDebug
+            questionsService: Configuration.current.isDebug && enableWarmupQuestionsSerivceStubInDebug
             ? WarmupQuestionsServiceStub(maxNumberOfQuestions: 3)
             : WarmupQuestionsServiceImpl(
                 networkService: .shared,
-                deviceIdProvider: AppSettings.isDebug ? DeviceIdProviderStub() : DeviceIdProviderImpl()
+                deviceIdProvider: Configuration.current.isDebug ? DeviceIdProviderStub() : DeviceIdProviderImpl()
             )
         )
         let router = WarmupRouter(

--- a/QuizPlease/PropertyLists/Info.plist
+++ b/QuizPlease/PropertyLists/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>Configuration</key>
+	<string>$(CONFIGURATION)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>ru</string>
 	<key>CFBundleExecutable</key>
@@ -99,6 +101,8 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>CFBundleDisplayName</key>
+	<string>$(APP_NAME)</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
 </dict>

--- a/QuizPlease/Services/Analytics/AnalyticsService.swift
+++ b/QuizPlease/Services/Analytics/AnalyticsService.swift
@@ -21,7 +21,7 @@ protocol AnalyticsService {
 final class AnalyticsServiceImpl: AnalyticsService {
 
     func sendEvent(_ event: AnalyticsEvent) {
-        guard !AppSettings.isDebug else { return }
+        guard !Configuration.current.isDebug else { return }
         Analytics.logEvent(event.name, parameters: event.parameters)
     }
 }

--- a/QuizPlease/Services/Network/Configuration/NetworkConfiguration.swift
+++ b/QuizPlease/Services/Network/Configuration/NetworkConfiguration.swift
@@ -9,23 +9,30 @@
 import Foundation
 
 public enum NetworkConfiguration: CustomStringConvertible {
-    case dev, prod
+    case staging, production
 
-    public static let standard: NetworkConfiguration = .dev
+    public static let standard: NetworkConfiguration = {
+        switch Configuration.current {
+        case .debug, .staging:
+            return .staging
+        case .production:
+            return .production
+        }
+    }()
 
     var host: String {
         switch self {
-        case .dev:
+        case .staging:
             return "https://staging.quizplease.ru:81/"
-        case .prod:
+        case .production:
             return "https://quizplease.ru/"
         }
     }
 
     private var identifier: String {
         switch self {
-        case .dev: return "dev"
-        case .prod: return "prod"
+        case .staging: return "staging"
+        case .production: return "production"
         }
     }
 

--- a/QuizPlease/Services/PaymentProvider/YooMoneyPaymentProvider.swift
+++ b/QuizPlease/Services/PaymentProvider/YooMoneyPaymentProvider.swift
@@ -28,7 +28,7 @@ final class YooMoneyPaymentProvider: PaymentProvider {
             purchaseDescription: options.description,
             amount: paymentAmount,
             gatewayId: nil,
-            isLoggingEnabled: AppSettings.isDebug,
+            isLoggingEnabled: Configuration.current.isDebug,
             userPhoneNumber: options.userPhoneNumber,
             savePaymentMethod: .off,
             moneyAuthClientId: nil,

--- a/QuizPlease/Shared/Models/AppSettings.swift
+++ b/QuizPlease/Shared/Models/AppSettings.swift
@@ -38,14 +38,6 @@ public enum AppSettings {
         URL(string: "https://apps.apple.com/ru/app/id1585713090")!
     }()
 
-    public static var isDebug: Bool {
-        #if DEBUG
-        return true
-        #else
-        return false
-        #endif
-    }
-
     public static var description: String {
         """
         AppSettings: {
@@ -53,7 +45,7 @@ public enum AppSettings {
             defaultCity: \(defaultCity)
             isShopEnabled: \(isShopEnabled)
             isProfileEnabled: \(isProfileEnabled)
-            isDebug: \(isDebug)
+            configuration: \(Configuration.current)
         }
         """
     }


### PR DESCRIPTION
1. Add build config files: Debug, Staging, Production
2. Edit build configs in project to match config files
3. Create build schemes according config files, delete the default build scheme
4. Match build configurations to CocoaPods presets in Podfile
5. Add configurations for Test target in Podfile
6. Run `pod install` and commit the changes in pbxproj
7. To fix CocoaPods warning, in Project Navigator "Test Target" -> "Build Settings" -> "Header Search Paths", add $(inherited) as the first line
8. To build Test target, select correct build configuration (Debug)
9. Add `Configuration` property in Info.plist
10. Add `Configuration` enum to read current build configuration from Info.plist
11. Remove `isDebug` property from `AppSettings`. Instead of macros wrapper, use the value from Configuration enum
12. Show debug applink alert (for unsuccessful cases) and debug info alert (in Main menu) in both staging and debug configs (Previously, alerts were shown only in Debug mode).
13. In NetworkConfiguration, use Configuration to determine the standard config. Also, rename dev -> staging, prod -> production
14. Use APP_NAME build config property as Bundle Display Name in Info.plist